### PR TITLE
Load FloatingNav only on home with fade-in animation

### DIFF
--- a/app/ui/components/FloatingNav/index.jsx
+++ b/app/ui/components/FloatingNav/index.jsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useState } from 'react';
+import { motion } from "motion/react";
 
 const handleClick = () => {
         window.scrollTo({
@@ -14,21 +15,21 @@ function FloatingNav(){
 
         useEffect(() => {
                 const sectionElements = Array.from(document.querySelectorAll('section[id]'));
-				const toFilterOut = (item) => {
-					const heading = item.querySelector('h2');
-					return heading && !item.classList.contains('hide-from-nav');
-				}
-				const toLoop = (item) => {
-					const heading = item.querySelector('h2');
-					return {
-						id: item.id,
-						label: heading.textContent.trim()
-					};
-				}
-				const data = sectionElements.filter(section => toFilterOut(section))
-				.map(section => toLoop(section));
-                
-				setSections(data);
+                const toFilterOut = (item) => {
+                        const heading = item.querySelector('h2');
+                        return heading && !item.classList.contains('hide-from-nav');
+                }
+                const toLoop = (item) => {
+                        const heading = item.querySelector('h2');
+                        return {
+                                id: item.id,
+                                label: heading.textContent.trim()
+                        };
+                }
+                const data = sectionElements.filter(section => toFilterOut(section))
+                .map(section => toLoop(section));
+
+                setSections(data);
 
                 const observer = new IntersectionObserver(entries => {
                         entries.forEach(entry => {
@@ -48,19 +49,31 @@ function FloatingNav(){
         }, []);
 
         return(
-                <div className="floatingNav">
-                        <nav className="floatingNav__nav">
-                                {sections.map(({id, label}) => (
-                                        <a key={id} href={`#${id}`}>{label}</a>
-                                ))}
-                        </nav>
-                        <button aria-label='Back to top' className="floatingNav__backTop" onClick={handleClick}>
-                                <svg width="33" height="33" viewBox="0 0 33 33" fill="none" xmlns="http://www.w3.org/2000/svg">
-                                        <path className="fill-bg" d="M3 0.5H30C31.3807 0.5 32.5 1.61929 32.5 3V32.5H0.5V3C0.5 1.61929 1.61929 0.5 3 0.5Z"/>
-                                        <path className="stroke-accent" strokeWidth="1" d="M23.5 19.5002L16.5 13.5002L9.50024 19.4998"/>
-                                </svg>
-                        </button>
-                </div>
+                sections.length > 0 && (
+                        <motion.div
+                                className="floatingNav"
+                                initial={{ opacity: 0 }}
+                                animate={{ opacity: 1 }}
+                                transition={{
+                                        duration: .01,
+                                        type: "spring",
+                                        stiffness: 200,
+                                        damping: 30
+                                }}
+                        >
+                                <nav className="floatingNav__nav">
+                                        {sections.map(({id, label}) => (
+                                                <a key={id} href={`#${id}`}>{label}</a>
+                                        ))}
+                                </nav>
+                                <button aria-label='Back to top' className="floatingNav__backTop" onClick={handleClick}>
+                                        <svg width="33" height="33" viewBox="0 0 33 33" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                                <path className="fill-bg" d="M3 0.5H30C31.3807 0.5 32.5 1.61929 32.5 3V32.5H0.5V3C0.5 1.61929 1.61929 0.5 3 0.5Z"/>
+                                                <path className="stroke-accent" strokeWidth="1" d="M23.5 19.5002L16.5 13.5002L9.50024 19.4998"/>
+                                        </svg>
+                                </button>
+                        </motion.div>
+                )
         )
 }
 

--- a/app/ui/modules/Header/index.jsx
+++ b/app/ui/modules/Header/index.jsx
@@ -1,20 +1,26 @@
+'use client';
+
 import { NameTitle } from '@/app/content/BodyContent';
 import FloatingNav from '../../components/FloatingNav';
+import { usePathname } from 'next/navigation';
 
 function Header(){
-    return(
-        <header className="header">
-			<div className="container">
-				<h1 className="header__sitename">
-					<a href="/">
-						<span className='highlight'>{NameTitle.name}</span>
-						<span>{NameTitle.title}</span>
-					</a>
-				</h1>
-			</div>
-			<FloatingNav/>
-        </header>
-    )
+        const pathname = usePathname();
+
+        return(
+                <header className="header">
+                        <div className="container">
+                                <h1 className="header__sitename">
+                                        <a href="/">
+                                                <span className='highlight'>{NameTitle.name}</span>
+                                                <span>{NameTitle.title}</span>
+                                        </a>
+                                </h1>
+                        </div>
+                        {pathname === '/' && <FloatingNav/>}
+                </header>
+        )
 }
 
 export default Header;
+


### PR DESCRIPTION
## Summary
- Render FloatingNav only on home page using `usePathname`
- Animate FloatingNav fade-in after links are loaded with motion/react

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689f800dac38832cb4b5bd00f1abea08